### PR TITLE
refactor: new layout and dark theme

### DIFF
--- a/components/ColorCard.tsx
+++ b/components/ColorCard.tsx
@@ -10,14 +10,14 @@ export default function ColorCard({ color, name }: ColorCardProps) {
       className={`flex flex-col flex-1 mx-2  uppercase text-center overflow-hidden rounded ${
         isBase
           ? 'border-2 border-blue-500 shadow-md bg-blue-500 text-white'
-          : 'border border-grey-200 bg-white text-gray-500'
+          : 'border border-grey-200 bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-50 dark:border-gray-700'
       }`}
     >
       <div className="w-full h-12 sm:h-16 md:h-20 lg:h-24 xl:h-28 2xl:h-32" style={{ backgroundColor: color }}></div>
       <div className="px-4 py-2">
         <div>{name}</div>
         <div>
-          <span className={`font-bold ${isBase ? 'text-gray-300' : 'text-gray-900'}`}>{color}</span>
+          <span className={`font-bold ${isBase ? 'text-gray-300' : 'text-gray-900 dark:text-gray-50'}`}>{color}</span>
         </div>
       </div>
     </div>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -8,8 +8,8 @@ export default function Nav() {
   const router = useRouter();
 
   return (
-    <nav>
-      <ul className="flex items-center p-8">
+    <nav className="fixed w-screen bg-white xl:bg-transparent 2xl:bg-transparent dark:bg-gray-900">
+      <ul className="flex items-center p-4">
         {router.pathname !== '/primary' && (
           <li>
             <LinkIcon href="/" title="Start over" icon={faAngleDoubleLeft} />

--- a/pages/brand.tsx
+++ b/pages/brand.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useContext, useEffect } from 'react';
+import { isEmpty } from 'lodash/fp';
 
 import { generateBrand, generatePalette } from '@utils/colors';
 import { DispatchContext, StateContext, SET_BRAND_COLOR } from '@utils/state';
@@ -11,7 +12,7 @@ import Nav from '@components/Nav';
 
 export default function BrandPage() {
   const [brand, setBrand] = useState('');
-  const [paletteGenerated, setPaletteGenerated] = useState(false);
+  const [paletteGenerated, setPaletteGenerated] = useState([]);
   const [error, setError] = useState('');
   const state = useContext(StateContext);
   const dispatch = useContext(DispatchContext);
@@ -21,16 +22,16 @@ export default function BrandPage() {
     if (!state.primary && !state.contrast) {
       router.replace('/primary');
     }
-    setBrand(state.brand);
     if (state.brand) {
-      setPaletteGenerated(true);
+      setBrand(state.brand);
+      setPaletteGenerated(generatePalette(state.brand, { direction: 'both', nbVariation: 6, increment: 5 }));
     }
   }, []);
 
   const onClickGenerate = (e) => {
     e.preventDefault();
     setError('');
-    setPaletteGenerated(false);
+    setPaletteGenerated([]);
 
     try {
       if (!brand) {
@@ -39,13 +40,12 @@ export default function BrandPage() {
       }
       const brandColor = generateBrand(brand, state.primary);
       setBrand(brandColor);
+      setPaletteGenerated(generatePalette(brandColor, { direction: 'both', nbVariation: 6, increment: 5 }));
       dispatch({ type: SET_BRAND_COLOR, brand: brandColor });
     } catch (error) {
       setError(error.message);
       setBrand(error.brand);
       dispatch({ type: SET_BRAND_COLOR, brand: error.brand });
-    } finally {
-      setPaletteGenerated(true);
     }
   };
 
@@ -59,73 +59,75 @@ export default function BrandPage() {
         />
       </Head>
       <Nav />
-      <div className="container p-10 mx-auto">
-        <div className="py-5">
-          <h1 className="page-title from-blue-900 to-green-500">Now the color of your brand!</h1>
-          <h2 className="mt-5 text-xl text-center text-gray-200 text-gray-600">
-            This should be a vivid color, with a high contrast against your primary color.
-          </h2>
+      <div className="page-container">
+        <div className="page-left-container">
+          <h1 className="page-title from-blue-900 to-green-500 dark:from-blue-500 dark:to-green-400">
+            Now the color of your brand!
+          </h1>
+          <h2 className="mt-5">This should be a vivid color, with a high contrast against your primary color.</h2>
         </div>
-        <form onSubmit={onClickGenerate}>
-          <div className="flex flex-row justify-center mt-5">
-            <div className="flex flex-row justify-center mx-2 overflow-hidden border border-gray-200 rounded">
-              <label htmlFor="hex" className="flex px-4 py-2 text-gray-400 bg-gray-100 rounder-l">
-                #
-              </label>
-              <input
-                className="px-2 text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-                onChange={(e) => {
-                  setError('');
-                  setBrand(`#${e.target.value}`);
-                }}
-                type="text"
-                name="hex"
-                id="hex"
-                placeholder="bada55"
-              />
-            </div>
-            <button type="submit" disabled={!brand} className="btn-blue">
-              Generate brand palette
-            </button>
-          </div>
-        </form>
-        {error && (
-          <div className="container mx-auto">
-            <div className="px-20 py-10 mt-10 font-bold text-center text-white bg-yellow-600 rounded">{error}</div>
-          </div>
-        )}
-        {paletteGenerated && (
-          <>
-            <div className="mt-10">
-              <h3 className="mx-2 mb-5 text-3xl font-bold text-gray-700">Brand:</h3>
-              <div className="flex flex-row justify-between mt-1">
-                {generatePalette(brand, { direction: 'both', nbVariation: 6, increment: 5 }).map(({ name, color }) => (
-                  <ColorCard key={color} color={color} name={name} />
-                ))}
+        <div className="page-right-container">
+          <form onSubmit={onClickGenerate}>
+            <div className="flex flex-row justify-center mt-5">
+              <div className="flex flex-row justify-center mx-2 overflow-hidden border border-gray-200 rounded">
+                <label htmlFor="hex" className="flex px-4 py-2 text-gray-400 bg-gray-100 rounder-l">
+                  #
+                </label>
+                <input
+                  className="px-2 text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+                  onChange={(e) => {
+                    setError('');
+                    setBrand(`#${e.target.value}`);
+                  }}
+                  type="text"
+                  name="hex"
+                  id="hex"
+                  placeholder="bada55"
+                />
               </div>
+              <button type="submit" disabled={!brand} className="btn-blue">
+                Generate brand palette
+              </button>
             </div>
-            <div className="mt-10">
-              <h3 className="mx-2 mb-5 text-3xl font-bold text-gray-700">Primary:</h3>
-              <div className="flex flex-row justify-between mt-1">
-                {generatePalette(state.primary, { direction: 'both', nbVariation: 6, increment: 5 }).map(
-                  ({ name, color }) => (
+          </form>
+          {error && (
+            <div className="container mx-auto">
+              <div className="px-20 py-10 mt-10 font-bold text-center text-white bg-yellow-600 rounded">{error}</div>
+            </div>
+          )}
+          {!isEmpty(paletteGenerated) && (
+            <>
+              <div className="mt-10">
+                <h3 className="mx-2 mb-5 text-3xl font-bold">Brand:</h3>
+                <div className="flex flex-row justify-between mt-1">
+                  {paletteGenerated.map(({ name, color }) => (
                     <ColorCard key={color} color={color} name={name} />
-                  ),
-                )}
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="flex flex-col mt-20 place-content-center">
-              <p className="text-2xl text-center text-gray-500">
-                If you are satisfied with those, we can go on to chose your state colors
-              </p>
-              <div className="flex mt-10 place-content-center">
-                <Link href="/states">
-                  <a className="btn-blue">Choose your state colors</a>
-                </Link>
+              <div className="mt-10">
+                <h3 className="mx-2 mb-5 text-3xl font-bold">Primary:</h3>
+                <div className="flex flex-row justify-between mt-1">
+                  {generatePalette(state.primary, { direction: 'both', nbVariation: 6, increment: 5 }).map(
+                    ({ name, color }) => (
+                      <ColorCard key={color} color={color} name={name} />
+                    ),
+                  )}
+                </div>
               </div>
-            </div>
-          </>
-        )}
+              <div className="flex flex-col mt-20 place-content-center">
+                <p className="text-2xl text-center">
+                  If you are satisfied with those, we can go on to chose your state colors
+                </p>
+                <div className="flex mt-10 place-content-center">
+                  <Link href="/states">
+                    <a className="btn-blue">Choose your state colors</a>
+                  </Link>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ export default function IndexPage() {
         <h1 className="p-5 mx-auto text-5xl font-bold text-center text-transparent w-max bg-clip-text bg-gradient-to-r from-pink-500 to-yellow-500">
           Swaatch!
         </h1>
-        <h2 className="mt-5 text-2xl text-center text-gray-500">Generate accessible color palettes easily.</h2>
+        <h2 className="mt-5 text-2xl text-center">Generate accessible color palettes easily.</h2>
         <div className="flex flex-row my-10 place-content-center">
           <Link href="/primary">
             <a className="btn-blue">Let's begin!</a>

--- a/pages/primary.tsx
+++ b/pages/primary.tsx
@@ -46,79 +46,79 @@ export default function PrimaryPage() {
         />
       </Head>
       <Nav />
-      <div className="container p-10 mx-auto">
-        <div className="py-5">
-          <h1 className="page-title from-gray-900 to-gray-500">First, the primary color!</h1>
-          <h2 className="mt-5 text-xl text-center text-gray-200 text-gray-600">
-            It should be either a really dark or really light color, leaning towards the grays
-          </h2>
-          <h2 className="mt-2 text-xl text-center text-gray-200 text-gray-600">
-            We will generate the best contrast for that color and then create some variants.
-          </h2>
+      <div className="page-container">
+        <div className="page-left-container">
+          <h1 className="page-title from-gray-900 to-gray-500 dark:from-gray-500 dark:to-gray-100">
+            First, the primary color!
+          </h1>
+          <h2 className="mt-5">It should be either a really dark or really light color, leaning towards the grays</h2>
+          <h2 className="mt-2">We will generate the best contrast for that color and then create some variants.</h2>
         </div>
-        <form onSubmit={onClickGenerate}>
-          <div className="flex flex-row justify-center mt-5">
-            <div className="flex flex-row justify-center mx-2 overflow-hidden border border-gray-200 rounded">
-              <label htmlFor="hex" className="flex px-4 py-2 text-gray-400 bg-gray-100 rounder-l">
-                #
-              </label>
-              <input
-                className="px-2 text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-                onChange={(e) => {
-                  setError('');
-                  setContrast('');
-                  setHexValue(`#${e.target.value}`);
-                }}
-                type="text"
-                name="hex"
-                id="hex"
-                placeholder="404040"
-              />
-            </div>
-            <button type="submit" disabled={!hexValue} className="btn-blue">
-              Generate contrast
-            </button>
-          </div>
-        </form>
-        {error && (
-          <div className="container mx-auto">
-            <div className="px-20 py-10 mt-10 font-bold text-center text-white bg-yellow-600 rounded">{error}</div>
-          </div>
-        )}
-        {contrast && (
-          <>
-            <div className="mt-20">
-              <h3 className="mx-2 text-3xl font-bold text-gray-700">Primary:</h3>
-              <div className="flex flex-row justify-between mt-1">
-                {generatePalette(hexValue, { direction: 'both', nbVariation: 6, increment: 5 }).map(
-                  ({ name, color }) => (
-                    <ColorCard key={color} color={color} name={name} />
-                  ),
-                )}
+        <div className="page-right-container">
+          <form onSubmit={onClickGenerate}>
+            <div className="flex flex-row justify-center mt-5">
+              <div className="flex flex-row justify-center mx-2 overflow-hidden border border-gray-200 rounded">
+                <label htmlFor="hex" className="flex px-4 py-2 text-gray-400 bg-gray-100 rounder-l">
+                  #
+                </label>
+                <input
+                  className="px-2 text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+                  onChange={(e) => {
+                    setError('');
+                    setContrast('');
+                    setHexValue(`#${e.target.value}`);
+                  }}
+                  type="text"
+                  name="hex"
+                  id="hex"
+                  placeholder="404040"
+                />
               </div>
+              <button type="submit" disabled={!hexValue} className="btn-blue">
+                Generate contrast
+              </button>
             </div>
-            <div className="mt-10">
-              <h3 className="mx-2 text-3xl font-bold text-gray-700">Contrast:</h3>
-              <div className="flex flex-row justify-between mt-1">
-                {generatePalette(contrast, { direction: 'both', nbVariation: 6, increment: 5 }).map(
-                  ({ name, color }) => (
-                    <ColorCard key={color} color={color} name={name} />
-                  ),
-                )}
+          </form>
+          {error && (
+            <div className="container mx-auto">
+              <div className="px-20 py-10 mt-10 font-bold text-center text-white bg-yellow-600 rounded">{error}</div>
+            </div>
+          )}
+          {contrast && (
+            <>
+              <div className="mt-20">
+                <h3 className="mx-2 text-3xl font-bold">Primary:</h3>
+                <div className="flex flex-row justify-between mt-1">
+                  {generatePalette(hexValue, { direction: 'both', nbVariation: 6, increment: 5 }).map(
+                    ({ name, color }) => (
+                      <ColorCard key={color} color={color} name={name} />
+                    ),
+                  )}
+                </div>
               </div>
-            </div>
-            <div className="flex flex-col mt-20 place-content-center">
-              <p className="text-2xl text-center text-gray-500">
-                If you are satisfied with those, we can go on to chose your brand color
-              </p>
-              <div className="flex mt-10 place-content-center">
-                <Link href="/brand">
-                  <a className="btn-blue">Choose your brand color</a>
-                </Link>
+              <div className="mt-10">
+                <h3 className="mx-2 text-3xl font-bold">Contrast:</h3>
+                <div className="flex flex-row justify-between mt-1">
+                  {generatePalette(contrast, { direction: 'both', nbVariation: 6, increment: 5 }).map(
+                    ({ name, color }) => (
+                      <ColorCard key={color} color={color} name={name} />
+                    ),
+                  )}
+                </div>
               </div>
-            </div>
-          </>
-        )}
+              <div className="flex flex-col mt-20 place-content-center">
+                <p className="text-2xl text-center">
+                  If you are satisfied with those, we can go on to chose your brand color
+                </p>
+                <div className="flex mt-10 place-content-center">
+                  <Link href="/brand">
+                    <a className="btn-blue">Choose your brand color</a>
+                  </Link>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/pages/states.tsx
+++ b/pages/states.tsx
@@ -76,57 +76,61 @@ export default function StatesPage() {
         />
       </Head>
       <Nav />
-      <div className="container p-10 mx-auto">
-        <div className="py-5">
-          <h1 className="page-title from-purple-500 to-red-500">Time to select your application state colors!</h1>
-          <h2 className="mt-5 text-xl text-center text-gray-200 text-gray-600">
+      <div className="page-container">
+        <div className="page-left-container">
+          <h1 className="page-title from-purple-500 to-red-500 dark:from-purple-400 dark:to-red-400">
+            Time to select your application state colors!
+          </h1>
+          <h2 className="mt-5">
             The state colors are used to indicate success, informations, warnings or failures and they are usually
             shades of green, blue, orange and red respectively.
           </h2>
         </div>
-        {Object.values(displayedStates)
-          .map(Boolean)
-          .includes(true) && (
-          <div className="mt-10">
-            <h3 className="mx-2 text-3xl font-bold text-gray-700">State colors</h3>
-            <div className="flex flex-col mt-2">
-              {Object.entries(displayedStates)
-                .filter(([_, color]) => Boolean(color))
-                .map(([state, color]) => (
-                  <Fragment key={color}>
-                    <h3 className="mx-2 mt-5 text-2xl font-bold text-gray-700 capitalize">
-                      <label className="">
-                        <span className={`mr-2 ${selectedStates[state] ? 'text-blue-500' : 'text-gray-500'}`}>
-                          <FontAwesomeIcon icon={selectedStates[state] ? faCheckCircle : farCheckCircle} />
-                        </span>
-                        <input
-                          onClick={() => toggleSelectState(state)}
-                          className="hidden"
-                          type="checkbox"
-                          checked={selectedStates[state]}
-                          value={selectedStates[state]}
-                        />
-                        {state}
-                      </label>
-                    </h3>
-                    <div key={state} className="flex flex-row justify-center mt-2">
-                      {generatePalette(color, { direction: 'both', nbVariation: 6, increment: 5 }).map(
-                        ({ name, color }) => (
-                          <ColorCard key={name} color={color} name={name} />
-                        ),
-                      )}
-                    </div>
-                  </Fragment>
-                ))}
+        <div className="page-right-container">
+          {Object.values(displayedStates)
+            .map(Boolean)
+            .includes(true) && (
+            <div className="mt-10">
+              <h3 className="mx-2 text-3xl font-bold">State colors</h3>
+              <div className="flex flex-col mt-2">
+                {Object.entries(displayedStates)
+                  .filter(([_, color]) => Boolean(color))
+                  .map(([state, color]) => (
+                    <Fragment key={color}>
+                      <h3 className="mx-2 mt-5 text-2xl font-bold capitalize">
+                        <label className="">
+                          <span className={`mr-2 ${selectedStates[state] ? 'text-blue-500' : ''}`}>
+                            <FontAwesomeIcon icon={selectedStates[state] ? faCheckCircle : farCheckCircle} />
+                          </span>
+                          <input
+                            onClick={() => toggleSelectState(state)}
+                            className="hidden"
+                            type="checkbox"
+                            checked={selectedStates[state]}
+                            value={selectedStates[state]}
+                          />
+                          {state}
+                        </label>
+                      </h3>
+                      <div key={state} className="flex flex-row justify-center mt-2">
+                        {generatePalette(color, { direction: 'both', nbVariation: 6, increment: 5 }).map(
+                          ({ name, color }) => (
+                            <ColorCard key={name} color={color} name={name} />
+                          ),
+                        )}
+                      </div>
+                    </Fragment>
+                  ))}
+              </div>
             </div>
-          </div>
-        )}
-        <div className="mt-10">
-          <h3 className="mx-2 text-3xl font-bold text-gray-700">Reminder</h3>
-          <div className="flex flex-row justify-between mt-1">
-            <ColorCard color={state.primary} name="Primary" />
-            <ColorCard color={state.contrast} name="Contrast" />
-            <ColorCard color={state.brand} name="Brand" />
+          )}
+          <div className="mt-10">
+            <h3 className="mx-2 text-3xl font-bold">Reminder</h3>
+            <div className="flex flex-row justify-between mt-1">
+              <ColorCard color={state.primary} name="Primary" />
+              <ColorCard color={state.contrast} name="Contrast" />
+              <ColorCard color={state.brand} name="Brand" />
+            </div>
           </div>
         </div>
       </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -12,11 +12,11 @@
 
 html,
 body {
-  @apply bg-gray-50;
+  @apply text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-50;
 }
 
 .page-wrapper {
-  @apply bg-gray-50;
+  @apply bg-white;
   width: 100vw;
   height: 100vh;
 }
@@ -51,15 +51,27 @@ body {
 }
 
 .btn-nav {
-  @apply flex items-center justify-center mr-4 text-gray-700 no-underline rounded-full cursor-pointer lg:px-8 xl:px-8 2xl:px-8 transition text-accent-1 h-14 w-14 min-w-max;
+  @apply flex items-center justify-center mr-4 text-gray-700 no-underline rounded-full cursor-pointer lg:px-8 xl:px-8 2xl:px-8 transition text-accent-1 h-14 w-14 min-w-max dark:text-gray-200;
 }
 
 .btn-nav:hover {
-  @apply bg-gray-200;
+  @apply bg-gray-200 dark:bg-gray-700;
+}
+
+.page-container {
+  @apply flex flex-col mx-auto sm:flex-col md:flex-col xl:flex-row 2xl:flex-row;
+}
+
+.page-left-container {
+  @apply flex flex-col items-center justify-center w-screen p-10 pt-28 xl:h-screen 2xl:h-screen xl:w-1/3 2xl:w-1/3 xl:items-start 2xl:items-start dark:text-gray-50;
 }
 
 .page-title {
-  @apply p-5 mx-auto text-xl font-bold text-center text-transparent sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl w-max bg-clip-text bg-gradient-to-r;
+  @apply min-w-full py-5 text-base font-bold text-center text-transparent sm:text-lg md:text-xl lg:text-2xl xl:text-3xl xl:text-left 2xl:text-left bg-clip-text bg-gradient-to-r;
+}
+
+.page-right-container {
+  @apply flex flex-col flex-grow h-screen px-10 bg-gray-100 2xl:overflow-auto xl:overflow-auto py-28 dark:bg-gray-800;
 }
 
 /* Your own custom utilities */


### PR DESCRIPTION
We are now using a new responsive layout.
A layout in 2 column for xl and 2xl tailwind breakpoint and 1 column for
the all other breakpoints.

We are also implementing a dark theme version.

We are also fixing a bug in the brand page that was concatenating new
brand color cards to old ones when changin the brand color value, with
the old ones becoming all black.